### PR TITLE
Setup CI 

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,0 +1,36 @@
+name: CI
+on: [push]
+
+jobs:
+  miniconda:
+    name: Miniconda ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: ["ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: orthomap
+          environment-file: environment.yml
+          python-version: 3.8
+          auto-activate-base: false
+      - shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - name: Install package
+        shell: bash -l {0}
+        run: |
+            pip install .
+      - name: Run pytest
+        shell: bash -l {0}
+        run: |
+            pytest tests
+    - name: Check that documentation builds
+      run: |
+        python -m pip install sphinx
+        python -m pip install sphinx_rtd_theme
+        python -m pip install mock
+        cd docs; make clean; make html; cd ..;

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,36 +1,35 @@
 name: CI
-on: [push]
+
+on: [pull_request]
 
 jobs:
-  miniconda:
-    name: Miniconda ${{ matrix.os }}
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
-        matrix:
-            os: ["ubuntu-latest"]
+      max-parallel: 2
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10"]
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: orthomap
-          environment-file: environment.yml
-          python-version: 3.8
-          auto-activate-base: false
-      - shell: bash -l {0}
-        run: |
-          conda info
-          conda list
-      - name: Install package
-        shell: bash -l {0}
-        run: |
-            pip install .
-      - name: Run pytest
-        shell: bash -l {0}
-        run: |
-            pytest tests
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+    - name: Install package
+      run: |
+        pip install .
     - name: Check that documentation builds
       run: |
         python -m pip install sphinx
         python -m pip install sphinx_rtd_theme
         python -m pip install mock
         cd docs; make clean; make html; cd ..;
+    - name: Run tests
+      run: |
+        pytest tests

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 2
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v1

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - pandas
   - ete3
   - scanpy
+  - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+ete3
+scanpy
+pytest


### PR DESCRIPTION
The easiest way to install the package was to include a `requirements.txt` file.

The test suite runs the tests for python 3.8 and 3.9 on an ubuntu build, and makes sure that the documentation builds. 

Let me know if you would like any changes 👍🏻 