### PR TITLE
Checking test suite

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 2
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/src/orthomap/datasets.py
+++ b/src/orthomap/datasets.py
@@ -11,8 +11,9 @@ License: GPL-3
 
 
 import os
-import wget
+
 import scanpy as sc
+import wget
 
 
 def ensembl105(datapath='.'):

--- a/src/orthomap/eggnog2orthomap.py
+++ b/src/orthomap/eggnog2orthomap.py
@@ -10,12 +10,14 @@ License: GPL-3
 """
 
 
+import argparse
 import os
 import sys
-import argparse
+
 import pandas as pd
-from orthomap import qlin, of2orthomap
 from ete3 import NCBITaxa
+
+from orthomap import of2orthomap, qlin
 
 
 def define_parser():

--- a/src/orthomap/gtf2t2g.py
+++ b/src/orthomap/gtf2t2g.py
@@ -10,10 +10,11 @@ License: GPL-3
 """
 
 
-import os
-import sys
 import argparse
 import gzip
+import os
+import sys
+
 import pandas as pd
 
 

--- a/src/orthomap/ncbitax.py
+++ b/src/orthomap/ncbitax.py
@@ -10,8 +10,9 @@ License: GPL-3
 """
 
 
-import sys
 import argparse
+import sys
+
 from ete3 import NCBITaxa
 
 

--- a/src/orthomap/of2orthomap.py
+++ b/src/orthomap/of2orthomap.py
@@ -10,13 +10,15 @@ License: GPL-3
 """
 
 
+import argparse
 import os
 import sys
 import zipfile
-import argparse
+
 import pandas as pd
-from orthomap import qlin
 from ete3 import NCBITaxa
+
+from orthomap import qlin
 
 
 def define_parser():

--- a/src/orthomap/orthomap2tei.py
+++ b/src/orthomap/orthomap2tei.py
@@ -7,11 +7,12 @@ License: GPL-3
 
 
 import os
-import scipy
+
+import anndata as ad
 import numpy as np
 import pandas as pd
-import anndata as ad
 import scanpy as sc
+import scipy
 from alive_progress import alive_bar
 
 

--- a/src/orthomap/qlin.py
+++ b/src/orthomap/qlin.py
@@ -10,8 +10,9 @@ License: GPL-3
 """
 
 
-import sys
 import argparse
+import sys
+
 import pandas as pd
 from ete3 import NCBITaxa, Tree
 

--- a/tests/test_eggnog2orthomap.py
+++ b/tests/test_eggnog2orthomap.py
@@ -1,0 +1,8 @@
+import argparse
+
+from orthomap import eggnog2orthomap
+
+
+def test_define_parse():
+    parse = eggnog2orthomap.define_parser()
+    assert isinstance(parse, argparse.ArgumentParser)

--- a/tests/test_gtf2t2g.py
+++ b/tests/test_gtf2t2g.py
@@ -1,20 +1,28 @@
 #!/usr/bin/python
 # -*- coding: UTF-8 -*-
 
+import argparse
+
 import pandas as pd
-from orthomap import gtf2t2g, datasets
 
+from orthomap import datasets, gtf2t2g
 
-file = datasets.mouse_gtf(datapath='/tmp')
+file = datasets.mouse_gtf(datapath="/tmp")
 expected_columns = [
-    'gene_id',
-    'gene_id_version',
-    'transcript_id',
-    'transcript_id_version',
-    'gene_name',
-    'gene_type',
-    'protein_id',
-    'protein_id_version']
+    "gene_id",
+    "gene_id_version",
+    "transcript_id",
+    "transcript_id_version",
+    "gene_name",
+    "gene_type",
+    "protein_id",
+    "protein_id_version",
+]
+
+
+def test_define_parse():
+    parse = gtf2t2g.define_parser()
+    assert isinstance(parse, argparse.ArgumentParser)
 
 
 def test_gtf2t2g_only_filename():
@@ -22,22 +30,23 @@ def test_gtf2t2g_only_filename():
     assert (output.columns == expected_columns).all()
     assert isinstance(output, pd.DataFrame)
     empty_columns = [
-        'gene_id_version',
-        'transcript_id_version',
-        'gene_name',
-        'gene_type',
-        'protein_id',
-        'protein_id_version']
+        "gene_id_version",
+        "transcript_id_version",
+        "gene_name",
+        "gene_type",
+        "protein_id",
+        "protein_id_version",
+    ]
     for col in empty_columns:
         assert len(output[col].unique()) == 1
-        assert output[col].unique()[0] == 'None' or output[col].unique()[0] is None
+        assert output[col].unique()[0] == "None" or output[col].unique()[0] is None
 
 
 def test_gtf2t2g_with_gene_type_and_versions():
     output = gtf2t2g.parse_gtf(file, g=True, b=True, v=True, q=True)
     assert (output.columns == expected_columns).all()
     assert isinstance(output, pd.DataFrame)
-    empty_columns = ['protein_id', 'protein_id_version']
+    empty_columns = ["protein_id", "protein_id_version"]
     for col in empty_columns:
         assert len(output[col].unique()) == 1
         assert output[col].unique()[0] is None
@@ -48,39 +57,37 @@ def test_gtf2t2g_with_gene_protein_id_version():
     assert (output.columns == expected_columns).all()
     assert isinstance(output, pd.DataFrame)
     empty_columns = [
-        'gene_id_version',
-        'transcript_id_version',
-        'gene_type',
-        'protein_id_version']
+        "gene_id_version",
+        "transcript_id_version",
+        "gene_type",
+        "protein_id_version",
+    ]
     for col in empty_columns:
         assert len(output[col].unique()) == 1
-        assert output[col].unique()[0] == 'None' or output[col].unique()[0] is None
+        assert output[col].unique()[0] == "None" or output[col].unique()[0] is None
 
 
 def test_mus_musculus():
     expected_first_row = [
-        'ENSMUSG00000000001',
-        'ENSMUSG00000000001.5',
-        'ENSMUST00000000001',
-        'ENSMUST00000000001.5',
-        'Gnai3',
+        "ENSMUSG00000000001",
+        "ENSMUSG00000000001.5",
+        "ENSMUST00000000001",
+        "ENSMUST00000000001.5",
+        "Gnai3",
         None,
-        'ENSMUSP00000000001',
-        'ENSMUSP00000000001.5']
+        "ENSMUSP00000000001",
+        "ENSMUSP00000000001.5",
+    ]
     expected_last_row = [
-        'ENSMUSG00002076992',
-        'ENSMUSG00002076992.1',
-        'ENSMUST00020181762',
-        'ENSMUST00020181762.1',
-        '7SK',
+        "ENSMUSG00002076992",
+        "ENSMUSG00002076992.1",
+        "ENSMUST00020181762",
+        "ENSMUST00020181762.1",
+        "7SK",
         None,
         None,
-        None]
+        None,
+    ]
     output = gtf2t2g.parse_gtf(file, g=True, p=True, s=True, q=True, v=True)
     assert (output.iloc[0].values == expected_first_row).all()
     assert (output.iloc[-1].values == expected_last_row).all()
-
-
-def test_duplicates():
-    # Need KU help here.
-    pass

--- a/tests/test_ncbitax.py
+++ b/tests/test_ncbitax.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 # -*- coding: UTF-8 -*-
 
-from orthomap import ncbitax
 import argparse
 import os
+
+from orthomap import ncbitax
 
 
 def test_define_parse():

--- a/tests/test_of2orthomap.py
+++ b/tests/test_of2orthomap.py
@@ -1,12 +1,18 @@
 #!/usr/bin/python
 # -*- coding: UTF-8 -*-
 
-import pandas as pd
-from orthomap import of2orthomap, datasets
+import argparse
 
+import pandas as pd
+
+from orthomap import datasets, of2orthomap
 
 ensembl105_oc, ensembl105_og, ensembl105_sl = datasets.ensembl105('/tmp')
 
+
+def test_define_parse():
+    parse = of2orthomap.define_parser()
+    assert isinstance(parse, argparse.ArgumentParser)
 
 def test_of2orthomap_continuity_false():
     query_orthomap, orthofinder_species_list, of_species_abundance = of2orthomap.get_orthomap(

--- a/tests/test_orthomap2tei.py
+++ b/tests/test_orthomap2tei.py
@@ -2,7 +2,8 @@
 # -*- coding: UTF-8 -*-
 
 import pandas as pd
-from orthomap import orthomap2tei, datasets
+
+from orthomap import datasets, orthomap2tei
 
 
 def test_read_orthomap():
@@ -66,22 +67,9 @@ def test_split_gene_id_by_gene_age():
     pass
 
 
-def test_get_ps():
+def test_get_psd():
     # No data to run the example.
     pass
-
-
-def test_get_pmatrix():
-    pass
-
-
-def test_get_tei():
-    pass
-
-
-def test_get_pstrata():
-    pass
-
 
 def test_min_max_to_01():
     ndarray_example_one = [1 for _ in range(5)]

--- a/tests/test_qlin.py
+++ b/tests/test_qlin.py
@@ -2,8 +2,10 @@
 # -*- coding: UTF-8 -*-
 
 import argparse
+
 import pandas as pd
 from ete3 import NCBITaxa, Tree
+
 from orthomap import qlin
 
 


### PR DESCRIPTION
Hey @kullrich, 

I went over the test files and applied some minor changes. At the moment there are not more functions that I can test 👍🏻 😄 

Note that the package does not support python 3.8  (the `of2orthomap.py` break ) so we are currently testing on python 3.9 and 3.10. We should make this clear somewhere, like in the `ReadMe`. Later on `PyPi` we can also specify it. 


I have also made some modifications to the `documentation` but I won't open a `PR` for now. I will wait until the implementation is done 🚀 